### PR TITLE
Fix edit mode check

### DIFF
--- a/tab-redirect-card.js
+++ b/tab-redirect-card.js
@@ -10,8 +10,7 @@ class TabRedirectCard extends HTMLElement {
 		if(!panel) { return; }
 		const uiRoot = panel.shadowRoot.querySelector('hui-root')
 		if(!uiRoot) { return; }
-		const header = uiRoot.shadowRoot.querySelector('app-header');
-		const isEditing = header.classList.contains('edit-mode');
+		const isEditing = uiRoot.shadowRoot.querySelector('.edit-mode');
 		if(isEditing) { return; }
 		let tabs = uiRoot.shadowRoot.querySelector('ha-tabs');
 		if(!tabs) {


### PR DESCRIPTION
Resolves `null is not an object (evaluating 'header.classList")` after upgrade to HA v2023.4

Not sure if this fix is backward compatible - will try to get an old instance installed to check, but if someone has that available that would be great

fixes #6 